### PR TITLE
Parse format (xml or text) when editing config

### DIFF
--- a/src/NcclientLibrary/NcclientKeywords.py
+++ b/src/NcclientLibrary/NcclientKeywords.py
@@ -183,7 +183,7 @@ class NcclientKeywords(object):
             raise str(e)
 
     def edit_config(self, alias, target, config, default_operation=None,
-                                    test_option=None, error_option=None):
+                    test_option=None, error_option=None, format='xml'):
         """
         Loads all or part of the specified config to the target
          configuration datastore.
@@ -203,6 +203,8 @@ class NcclientKeywords(object):
         ``error_option`` if specified must be one of
         { ?stop-on-error?, ?continue-on-error?, ?rollback-on-error? }
 
+	``format`` if specified must be one of { ?xml?, ?text?}
+
         The ?rollback-on-error? error_option depends on the :rollback-on-error
         adaptability.
 
@@ -213,8 +215,9 @@ class NcclientKeywords(object):
             logger.info("target: %s, config: %s, default_operation: %s \
                test_option: %s,  error_option: %s" 
                % (target, config, default_operation, test_option, error_option))
-            session.edit_config(target, config, default_operation, 
-                                    test_option, error_option)
+            session.edit_config(config, format, target, default_operation,
+				     test_option, error_option)
+
         except NcclientException as e:
             logger.error(str(e))
             raise str(e)


### PR DESCRIPTION
There was an issue with the passing of arguments in edit_config which resulted to failures when trying to write on running configuration datastore.

Moreover, according to the framework [documentation ][1], 
_"config is the configuration, which must be rooted in the config element. It can be specified either as a string or an Element"._ 
However, I tested with an object of type element and it is not working.

[1]: https://vkosuri.github.io/robotframework-ncclient/