### PR TITLE
handle look_for_keys parameter when establishing an ssh connection

### DIFF
--- a/src/NcclientLibrary/NcclientKeywords.py
+++ b/src/NcclientLibrary/NcclientKeywords.py
@@ -63,7 +63,21 @@ class NcclientKeywords(object):
     def connect(self, *args, **kwds):
         """
         Initialize a Manager over the SSH transport.
+
+         ``host`` the host to connect to
+
+         ``port`` the SSH port
+
+         ``username`` the username to use for SSH authentication
+
+         ``password`` the password to be used for password authentication
+
+          ``look_for_keys`` set to ``false`` to avoid searching for ssh keys
+
+          ``key_filename`` a filename where a private key can be found
+
         """
+
         try:
             logger.info('Creating session %s, %s' % (args, kwds))
             alias = kwds.get('alias')
@@ -73,6 +87,7 @@ class NcclientKeywords(object):
                 username=str(kwds.get('username')),
                 password=str(kwds.get('password')),
                 hostkey_verify=False,
+                look_for_keys= False if str(kwds.get('look_for_keys')).lower() == 'false' else True,
                 key_filename=str(kwds.get('key_filename')),
             )
             self._cache.register(session, alias=alias)


### PR DESCRIPTION
Hi,

When establishing an ssh connection, look_for_keys was not passed to ncclient which resulted to always searching for authentication keys under specific directories.
Now this search is bypassed if look_for_keys is set to false.

Regards
Nikos