### PR TITLE
Allow empty filters - "is not None"

### DIFF
--- a/src/NcclientLibrary/NcclientKeywords.py
+++ b/src/NcclientLibrary/NcclientKeywords.py
@@ -187,7 +187,7 @@ class NcclientKeywords(object):
         session = self._cache.switch(alias)
         gc_filter = None
         try:
-            if filter_criteria:
+            if filter_criteria is not None:
                 gc_filter = (filter_type, filter_criteria)
 
             logger.info("alias: %s, source: %s, filter: %s:" % (alias, source,
@@ -377,7 +377,7 @@ class NcclientKeywords(object):
         session = self._cache.switch(alias)
         get_filter = None
         try:
-            if filter_criteria:
+            if filter_criteria is not None:
                 get_filter = (filter_type, filter_criteria)
             return session.get(get_filter).data
         except NcclientException as e:


### PR DESCRIPTION
Corrects the issue #13 : changes the Get and Get Config keywords to avoid ignoring filter_criteria when filter_criteria doesnot contain any child.
Additionally: 
* Complies with [PEP8, Programmer Recommandation, bullet 2](https://peps.python.org/pep-0008/#programming-recommendations) (line 1102) which states "Also, beware of writing `if x` when you really mean `if x is not None`"; and [Google section 2.14.4 bullet 2](https://google.github.io/styleguide/pyguide.html#2144-decision) "Always use `if foo is None`: (or `is not None`) to check for a `None` value." 
* Remove the FutureWarning raised by LXML, which appear for any filter. (only if `use_lxml=True`) due to __bool__ method of the class Element of LXML.